### PR TITLE
feat(layout): anchor-based text placement, center_top; Korean date fo…

### DIFF
--- a/scripts/generate_week.py
+++ b/scripts/generate_week.py
@@ -38,7 +38,8 @@ def monday_of_week(d: dt.date) -> dt.date:
 
 def format_date_kr(d: dt.date) -> str:
     weekdays = "월화수목금토일"
-    return d.strftime(f"%Y-%m-%d ({weekdays[d.weekday()]})")
+    # e.g., 2025년09월03일 수요일
+    return f"{d.strftime('%Y년%m월%d일')} {weekdays[d.weekday()]}요일"
 
 
 def date_list(start: dt.date, days: int) -> List[dt.date]:

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -21,8 +21,8 @@ def now_kr() -> dt.datetime:
 
 def format_date_kr(d: dt.datetime) -> str:
     weekdays = "월화수목금토일"
-    # e.g., 2025-09-04 목요일
-    return f"{d.strftime('%Y-%m-%d')} {weekdays[d.weekday()]}요일"
+    # e.g., 2025년09월04일 목요일
+    return f"{d.strftime('%Y년%m월%d일')} {weekdays[d.weekday()]}요일"
 
 
 def build_caption(date_str, tt, school_name, grade, class_nm):


### PR DESCRIPTION
…rmat (YYYY년MM월DD일 요일)

- render_image: add DATE/SUBJECT anchor modes (topleft|center|center_top|left_center)
- support horizontal align within region for date/subject (ALIGN/ALIGN_X1|W)
- subject placement: per-template after-lunch anchor (5교시) + DY
- fonts: date 32 Bold, subject 40 Bold
- generator/daemon: date label uses ‘YYYY년MM월DD일 ?요일’

## Summary
변경 요약을 한두 문장으로 적어주세요.

## Details
- 변경 동기/배경:
- 주요 변경 파일:
- 주의할 점:

## Checklist
- [ ] 문서 반영 완료 (README.md / WINDOWS.md)
- [ ] 실행 확인: `python -m src.daemon --run-now` 로 이미지 생성 확인
- [ ] 필요 시 주간 생성 확인: `python scripts/generate_week.py`
- [ ] 환경값/키 문서화 (.env.example 갱신 필요 시 반영)
- [ ] 과목 치환 규칙 업데이트 시 `data/subject_aliases.json` 수정됨
- [ ] 스크립트 실행 권한 확인 (`scripts/*.sh` 는 실행 가능)
- [ ] GH Actions/시스템드 변경 시 설정 문서화 또는 워크플로 반영
- [ ] 민감정보/토큰이 커밋에 포함되지 않음

## Screenshots / Outputs (optional)
필요 시 `out/` 산출물 캡처 또는 로그 일부를 첨부하세요.

